### PR TITLE
Simplify cost estimation to use Inspect eval logs

### DIFF
--- a/analysis/cost_estimation.py
+++ b/analysis/cost_estimation.py
@@ -1,0 +1,237 @@
+"""Cost estimation helpers built around Inspect eval logs.
+
+Inspect's :func:`inspect_ai.eval` entrypoint returns :class:`inspect_ai.log.EvalLog`
+objects that already include aggregated token usage for each model involved in a
+run. This module provides small utilities to turn those logs into per-model
+usage summaries and then translate the summaries into projected costs for larger
+benchmark runs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+
+from inspect_ai.log import EvalLog
+from inspect_ai.model._model_output import ModelUsage
+
+
+@dataclass
+class UsageSummary:
+    """Aggregate token usage measured for a particular model."""
+
+    model: str
+    samples: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+    @property
+    def total_tokens(self) -> int:
+        """Total tokens consumed across all samples."""
+
+        return self.input_tokens + self.output_tokens
+
+    @property
+    def mean_input_tokens(self) -> float:
+        """Average number of input tokens per completed sample."""
+
+        return self.input_tokens / self.samples if self.samples else 0.0
+
+    @property
+    def mean_output_tokens(self) -> float:
+        """Average number of output tokens per completed sample."""
+
+        return self.output_tokens / self.samples if self.samples else 0.0
+
+    @property
+    def mean_total_tokens(self) -> float:
+        """Average number of total tokens per completed sample."""
+
+        return self.total_tokens / self.samples if self.samples else 0.0
+
+
+@dataclass(frozen=True)
+class ModelPricing:
+    """Per-million token pricing for a language model."""
+
+    provider: str
+    model: str
+    input_per_million: float
+    output_per_million: float
+    currency: str = "USD"
+
+
+@dataclass(frozen=True)
+class CostEstimate:
+    """Projected spend for a benchmark run on a specific model."""
+
+    provider: str
+    model: str
+    currency: str
+    input_tokens: int
+    output_tokens: int
+    input_cost: float
+    output_cost: float
+
+    @property
+    def total_cost(self) -> float:
+        return self.input_cost + self.output_cost
+
+
+def summarise_eval_log(log: EvalLog) -> UsageSummary | None:
+    """Convert a single Inspect eval log into a :class:`UsageSummary`.
+
+    Parameters
+    ----------
+    log:
+        Evaluation log returned by :func:`inspect_ai.eval` or loaded from disk
+        with :func:`inspect_ai.log.read_eval_log`.
+    """
+
+    samples = 0
+    if log.results is not None:
+        samples = log.results.completed_samples or log.results.total_samples or 0
+
+    if samples == 0:
+        return None
+
+    usage = _primary_model_usage(log)
+    if usage is None:
+        return None
+
+    return UsageSummary(
+        model=log.eval.model,
+        samples=samples,
+        input_tokens=usage.input_tokens,
+        output_tokens=_output_tokens(usage),
+    )
+
+
+def summarise_eval_logs(logs: Sequence[EvalLog]) -> Mapping[str, UsageSummary]:
+    """Aggregate usage summaries for one or more eval logs."""
+
+    summaries: dict[str, UsageSummary] = {}
+    for log in logs:
+        summary = summarise_eval_log(log)
+        if summary is None:
+            continue
+
+        existing = summaries.get(summary.model)
+        if existing is None:
+            summaries[summary.model] = summary
+        else:
+            existing.samples += summary.samples
+            existing.input_tokens += summary.input_tokens
+            existing.output_tokens += summary.output_tokens
+
+    return summaries
+
+
+def scale_usage(summary: UsageSummary, target_games: int) -> UsageSummary:
+    """Scale a usage summary to a target number of Hangman games."""
+
+    if summary.samples == 0:
+        raise ValueError("Cannot scale usage: no samples provided")
+
+    factor = target_games / summary.samples
+    return UsageSummary(
+        model=summary.model,
+        samples=target_games,
+        input_tokens=int(round(summary.input_tokens * factor)),
+        output_tokens=int(round(summary.output_tokens * factor)),
+    )
+
+
+def estimate_cost(summary: UsageSummary, pricing: ModelPricing) -> CostEstimate:
+    """Estimate monetary cost given model pricing."""
+
+    input_cost = (summary.input_tokens / 1_000_000) * pricing.input_per_million
+    output_cost = (summary.output_tokens / 1_000_000) * pricing.output_per_million
+    return CostEstimate(
+        provider=pricing.provider,
+        model=pricing.model,
+        currency=pricing.currency,
+        input_tokens=summary.input_tokens,
+        output_tokens=summary.output_tokens,
+        input_cost=input_cost,
+        output_cost=output_cost,
+    )
+
+
+def project_costs(
+    summaries: Mapping[str, UsageSummary] | Sequence[UsageSummary],
+    target_games: int,
+    pricings: Iterable[ModelPricing],
+) -> list[CostEstimate]:
+    """Estimate evaluation costs for multiple models."""
+
+    if isinstance(summaries, Mapping):
+        summary_map = dict(summaries)
+    else:
+        summary_map = {summary.model: summary for summary in summaries}
+
+    estimates: list[CostEstimate] = []
+    for pricing in pricings:
+        summary = summary_map.get(pricing.model)
+        if summary is None:
+            raise KeyError(
+                f"No usage summary available for model '{pricing.model}'. "
+                "Call `summarise_eval_logs()` on your eval logs first."
+            )
+        scaled = scale_usage(summary, target_games)
+        estimates.append(estimate_cost(scaled, pricing))
+
+    return estimates
+
+
+def project_costs_from_eval_logs(
+    logs: Sequence[EvalLog],
+    target_games: int,
+    pricings: Iterable[ModelPricing],
+) -> list[CostEstimate]:
+    """Convenience wrapper around :func:`project_costs` for raw eval logs."""
+
+    summaries = summarise_eval_logs(logs)
+    return project_costs(summaries, target_games, pricings)
+
+
+def _primary_model_usage(log: EvalLog) -> ModelUsage | None:
+    """Extract aggregated usage for the primary model associated with a log."""
+
+    if not log.stats or not log.stats.model_usage:
+        return None
+
+    primary = log.eval.model
+    usage = log.stats.model_usage.get(primary)
+    if usage is not None:
+        return usage
+
+    return _sum_usage(log.stats.model_usage.values())
+
+
+def _sum_usage(usages: Iterable[ModelUsage]) -> ModelUsage:
+    total = ModelUsage()
+    for usage in usages:
+        total = total + usage
+    return total
+
+
+def _output_tokens(usage: ModelUsage) -> int:
+    if usage.output_tokens:
+        return usage.output_tokens
+
+    remainder = usage.total_tokens - usage.input_tokens
+    return remainder if remainder > 0 else 0
+
+
+__all__ = [
+    "UsageSummary",
+    "ModelPricing",
+    "CostEstimate",
+    "summarise_eval_log",
+    "summarise_eval_logs",
+    "scale_usage",
+    "estimate_cost",
+    "project_costs",
+    "project_costs_from_eval_logs",
+]

--- a/analysis/hangman_bench_experimental_plan.ipynb
+++ b/analysis/hangman_bench_experimental_plan.ipynb
@@ -1,0 +1,479 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Hangman Bench Experimental Plan\n",
+    "\n",
+    "This notebook captures a reproducible blueprint for analysing the Hangman Bench codebase, planning model evaluations, and preparing a research paper that reports the benchmark results."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Repository at a Glance\n",
+    "\n",
+    "The following code cell enumerates the key Python modules that implement the benchmark along with companion analysis utilities bundled with the repository."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "src_files = sorted(Path('src/hangman_bench').glob('**/*.py'))\n",
+    "analysis_files = sorted(Path('analysis').glob('*.py'))\n",
+    "\n",
+    "print('Source modules:')\n",
+    "for path in src_files:\n",
+    "    print(f\"  - {path}\")\n",
+    "\n",
+    "print('\\nAnalysis utilities:')\n",
+    "for path in analysis_files:\n",
+    "    print(f\"  - {path}\")"
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Source modules:\n",
+      "  - src/hangman_bench/__init__.py\n",
+      "  - src/hangman_bench/datasets.py\n",
+      "  - src/hangman_bench/hangman.py\n",
+      "\n",
+      "Analysis utilities:\n",
+      "  - analysis/bin_difficulty.py\n",
+      "  - analysis/cost_estimation.py\n",
+      "  - analysis/extract_wordlist.py\n",
+      "  - analysis/ingest_simulation.py\n",
+      "  - analysis/measure_difficulty.py\n",
+      "  - analysis/reclassified_from_coverage.py\n",
+      "  - analysis/reclassified_from_freq.py\n",
+      "  - analysis/reclassify_words.py\n",
+      "  - analysis/zen_hangman.py\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Dataset Composition\n",
+    "\n",
+    "Hangman Bench ships with a curated, difficulty-annotated English word list. The cell below summarises the distribution of words per difficulty tier and reports descriptive statistics that are relevant when sampling evaluation subsets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "source": [
+    "import importlib.util\n",
+    "from collections import Counter\n",
+    "from statistics import mean\n",
+    "from pathlib import Path\n",
+    "\n",
+    "spec = importlib.util.spec_from_file_location('hangman_datasets', Path('src/hangman_bench/datasets.py'))\n",
+    "datasets = importlib.util.module_from_spec(spec)\n",
+    "spec.loader.exec_module(datasets)\n",
+    "\n",
+    "words = datasets.get_words_by_language(datasets.Language.ENGLISH)\n",
+    "difficulty_counts = Counter(word.difficulty for word in words)\n",
+    "lengths = [len(word.word) for word in words]\n",
+    "\n",
+    "print(f\"Total words: {len(words)}\")\n",
+    "print('Difficulty distribution:')\n",
+    "for difficulty, count in sorted(difficulty_counts.items()):\n",
+    "    pct = (count / len(words)) * 100\n",
+    "    print(f\"  - {difficulty:7s}: {count:3d} words ({pct:5.1f}%)\")\n",
+    "\n",
+    "print('\\nWord length statistics:')\n",
+    "print(f\"  - Min: {min(lengths)} characters\")\n",
+    "print(f\"  - Median: {sorted(lengths)[len(lengths)//2]} characters\")\n",
+    "print(f\"  - Mean: {mean(lengths):.2f} characters\")\n",
+    "print(f\"  - Max: {max(lengths)} characters\")"
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total words: 100\n",
+      "Difficulty distribution:\n",
+      "  - easy   :  20 words ( 20.0%)\n",
+      "  - hard   :  20 words ( 20.0%)\n",
+      "  - medium :  20 words ( 20.0%)\n",
+      "  - v_easy :  20 words ( 20.0%)\n",
+      "  - v_hard :  20 words ( 20.0%)\n",
+      "\n",
+      "Word length statistics:\n",
+      "  - Min: 3 characters\n",
+      "  - Median: 6 characters\n",
+      "  - Mean: 6.28 characters\n",
+      "  - Max: 10 characters\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task Configuration Signals\n",
+    "\n",
+    "Because the Inspect runtime is an optional dependency, we analyse the task definition statically. The next cell parses `hangman.py` with Python's `ast` module to expose the default parameters that shape each evaluation run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "source": [
+    "from pathlib import Path\n",
+    "import ast\n",
+    "\n",
+    "source = Path('src/hangman_bench/hangman.py').read_text()\n",
+    "module = ast.parse(source)\n",
+    "\n",
+    "defaults = {}\n",
+    "constants = {}\n",
+    "\n",
+    "for node in module.body:\n",
+    "    if isinstance(node, ast.Assign):\n",
+    "        for target in node.targets:\n",
+    "            if isinstance(target, ast.Name):\n",
+    "                try:\n",
+    "                    constants[target.id] = ast.literal_eval(node.value)\n",
+    "                except Exception:\n",
+    "                    pass\n",
+    "    if isinstance(node, ast.FunctionDef) and node.name == 'hangman':\n",
+    "        args = node.args\n",
+    "        positional = args.args\n",
+    "        default_values = [None] * (len(positional) - len(args.defaults)) + list(args.defaults)\n",
+    "        for arg, default in zip(positional, default_values):\n",
+    "            if default is None:\n",
+    "                defaults[arg.arg] = None\n",
+    "            else:\n",
+    "                try:\n",
+    "                    defaults[arg.arg] = ast.literal_eval(default)\n",
+    "                except Exception:\n",
+    "                    defaults[arg.arg] = ast.unparse(default)\n",
+    "\n",
+    "print('Top-level constants:')\n",
+    "for key in sorted(constants):\n",
+    "    if key.isupper():\n",
+    "        print(f\"  - {key} = {constants[key]}\")\n",
+    "\n",
+    "print('\\n`hangman` task parameters:')\n",
+    "for key in defaults:\n",
+    "    print(f\"  - {key}: default={defaults[key]}\")"
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Top-level constants:\n",
+      "  - DEFAULT_MAX_GUESSES = 10\n",
+      "  - NUM_ALLOWABLE_EXTRA_MESSAGES = 5\n",
+      "\n",
+      "`hangman` task parameters:\n",
+      "  - language: default=DEFAULT_LANGUAGE.value\n",
+      "  - difficulty: default=None\n",
+      "  - max_guesses: default=DEFAULT_MAX_GUESSES\n",
+      "  - shuffle: default=True\n",
+      "  - allow_word_guesses: default=False\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Experiment Matrix\n",
+    "\n",
+    "The following experiment plan enumerates the benchmark scenarios we will run. Each row captures the evaluation axis, the hypothesis under test, and any task parameters that need to be toggled."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "source": [
+    "experiments = [\n",
+    "    {\n",
+    "        'axis': 'Difficulty sensitivity',\n",
+    "        'description': 'Evaluate performance separately on each difficulty tier to quantify robustness across easy and hard words.',\n",
+    "        'task_parameters': 'language=\"english\"; difficulty in {v_easy, easy, medium, hard, v_hard}',\n",
+    "        'primary_metrics': 'Grouped accuracy, stderr',\n",
+    "    },\n",
+    "    {\n",
+    "        'axis': 'Word guessing ability',\n",
+    "        'description': 'Allow full-word submissions to measure whether models leverage early inference versus letter-by-letter play.',\n",
+    "        'task_parameters': 'allow_word_guesses=True',\n",
+    "        'primary_metrics': 'Win rate, number of incorrect guesses',\n",
+    "    },\n",
+    "    {\n",
+    "        'axis': 'Guess budget',\n",
+    "        'description': 'Stress-test models with tighter mistake budgets (max_guesses in {6, 8, 10}) to see how strategic play adapts.',\n",
+    "        'task_parameters': 'max_guesses varied',\n",
+    "        'primary_metrics': 'Win rate, mean remaining guesses',\n",
+    "    },\n",
+    "    {\n",
+    "        'axis': 'Language generalisation',\n",
+    "        'description': 'If additional dictionaries are added, repeat the mixed-difficulty evaluation for each supported language.',\n",
+    "        'task_parameters': 'language varied; shuffle=True',\n",
+    "        'primary_metrics': 'Accuracy per language, stderr',\n",
+    "    },\n",
+    "]\n",
+    "\n",
+    "headers = ['Axis', 'Description', 'Task parameters', 'Primary metrics']\n",
+    "col_widths = []\n",
+    "for header, key in zip(headers, ['axis', 'description', 'task_parameters', 'primary_metrics']):\n",
+    "    col_width = len(header)\n",
+    "    for row in experiments:\n",
+    "        col_width = max(col_width, len(row[key]))\n",
+    "    col_widths.append(col_width)\n",
+    "\n",
+    "header_row = ' | '.join(header.ljust(width) for header, width in zip(headers, col_widths))\n",
+    "print(header_row)\n",
+    "print('-+-'.join('-' * width for width in col_widths))\n",
+    "for row in experiments:\n",
+    "    print(' | '.join(row[key].ljust(width) for key, width in zip(['axis', 'description', 'task_parameters', 'primary_metrics'], col_widths)))"
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Axis                    | Description                                                                                                   | Task parameters                                                        | Primary metrics                      \n",
+      "------------------------+---------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------+--------------------------------------\n",
+      "Difficulty sensitivity  | Evaluate performance separately on each difficulty tier to quantify robustness across easy and hard words.    | language=\"english\"; difficulty in {v_easy, easy, medium, hard, v_hard} | Grouped accuracy, stderr             \n",
+      "Word guessing ability   | Allow full-word submissions to measure whether models leverage early inference versus letter-by-letter play.  | allow_word_guesses=True                                                | Win rate, number of incorrect guesses\n",
+      "Guess budget            | Stress-test models with tighter mistake budgets (max_guesses in {6, 8, 10}) to see how strategic play adapts. | max_guesses varied                                                     | Win rate, mean remaining guesses     \n",
+      "Language generalisation | If additional dictionaries are added, repeat the mixed-difficulty evaluation for each supported language.     | language varied; shuffle=True                                          | Accuracy per language, stderr        \n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Target Model Coverage\n",
+    "\n",
+    "To turn the experiment matrix into a paper-ready benchmark, we curate a cross-provider model list. Costs will be projected using the helpers introduced later in this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "source": [
+    "models = [\n",
+    "    {\n",
+    "        'provider': 'OpenAI',\n",
+    "        'model': 'gpt-4o-mini',\n",
+    "        'notes': 'Fast baseline with tool-use support; primary benchmark anchor.',\n",
+    "    },\n",
+    "    {\n",
+    "        'provider': 'OpenAI',\n",
+    "        'model': 'gpt-4o',\n",
+    "        'notes': 'Higher-end capability reference for English Hangman.',\n",
+    "    },\n",
+    "    {\n",
+    "        'provider': 'Anthropic',\n",
+    "        'model': 'claude-3-5-sonnet',\n",
+    "        'notes': 'Latest Claude family model with strong reasoning.',\n",
+    "    },\n",
+    "    {\n",
+    "        'provider': 'Google',\n",
+    "        'model': 'gemini-2.0-flash-thinking',\n",
+    "        'notes': 'Gemini model with tool-use; evaluate instruction following.',\n",
+    "    },\n",
+    "    {\n",
+    "        'provider': 'Cohere',\n",
+    "        'model': 'command-r-plus',\n",
+    "        'notes': 'Tool-enabled Command series model for multilingual robustness.',\n",
+    "    },\n",
+    "]\n",
+    "\n",
+    "headers = ['Provider', 'Model', 'Notes']\n",
+    "col_widths = []\n",
+    "for header, key in zip(headers, ['provider', 'model', 'notes']):\n",
+    "    col_width = len(header)\n",
+    "    for entry in models:\n",
+    "        col_width = max(col_width, len(entry[key]))\n",
+    "    col_widths.append(col_width)\n",
+    "\n",
+    "print(' | '.join(header.ljust(width) for header, width in zip(headers, col_widths)))\n",
+    "print('-+-'.join('-' * width for width in col_widths))\n",
+    "for entry in models:\n",
+    "    print(' | '.join(entry[key].ljust(width) for key, width in zip(['provider', 'model', 'notes'], col_widths)))"
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Provider  | Model                     | Notes                                                         \n",
+      "----------+---------------------------+---------------------------------------------------------------\n",
+      "OpenAI    | gpt-4o-mini               | Fast baseline with tool-use support; primary benchmark anchor.\n",
+      "OpenAI    | gpt-4o                    | Higher-end capability reference for English Hangman.          \n",
+      "Anthropic | claude-3-5-sonnet         | Latest Claude family model with strong reasoning.             \n",
+      "Google    | gemini-2.0-flash-thinking | Gemini model with tool-use; evaluate instruction following.   \n",
+      "Cohere    | command-r-plus            | Tool-enabled Command series model for multilingual robustness.\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cost Projection Workflow\n",
+    "\n",
+    "The benchmark uses pilot runs to calibrate token usage and then extrapolates costs for full-scale experiments. The following code demonstrates the `analysis.cost_estimation` helpers with illustrative data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "source": [
+    "from datetime import datetime, timezone\n",
+    "\n",
+    "from inspect_ai.log import EvalLog\n",
+    "\n",
+    "from analysis.cost_estimation import (\n",
+    "    ModelPricing,\n",
+    "    project_costs,\n",
+    "    summarise_eval_logs,\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def fake_eval_log(model_name, samples, input_tokens, output_tokens):\n",
+    "    return EvalLog.model_validate(\n",
+    "        {\n",
+    "            \"status\": \"success\",\n",
+    "            \"eval\": {\n",
+    "                \"created\": datetime.now(timezone.utc).isoformat(),\n",
+    "                \"task\": \"hangman_bench/hangman\",\n",
+    "                \"model\": model_name,\n",
+    "                \"dataset\": {\"name\": \"hangman-sample\", \"samples\": samples},\n",
+    "                \"config\": {},\n",
+    "            },\n",
+    "            \"stats\": {\n",
+    "                \"model_usage\": {\n",
+    "                    model_name: {\n",
+    "                        \"input_tokens\": input_tokens,\n",
+    "                        \"output_tokens\": output_tokens,\n",
+    "                        \"total_tokens\": input_tokens + output_tokens,\n",
+    "                    }\n",
+    "                }\n",
+    "            },\n",
+    "            \"results\": {\n",
+    "                \"total_samples\": samples,\n",
+    "                \"completed_samples\": samples,\n",
+    "            },\n",
+    "        }\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "pilot_logs = [\n",
+    "    fake_eval_log(\"openai/gpt-4o-mini\", samples=3, input_tokens=2150, output_tokens=540),\n",
+    "    fake_eval_log(\"anthropic/claude-3-5-sonnet\", samples=3, input_tokens=2400, output_tokens=720),\n",
+    "]\n",
+    "\n",
+    "usage_summaries = summarise_eval_logs(pilot_logs)\n",
+    "\n",
+    "print(\"Per-model usage captured from Inspect logs:\")\n",
+    "for model, summary in usage_summaries.items():\n",
+    "    print(f\"  - {model}: {summary.samples} samples, {summary.total_tokens} total tokens\")\n",
+    "\n",
+    "pricing_table = [\n",
+    "    ModelPricing(provider=\"OpenAI\", model=\"openai/gpt-4o-mini\", input_per_million=0.15, output_per_million=0.60),\n",
+    "    ModelPricing(provider=\"Anthropic\", model=\"anthropic/claude-3-5-sonnet\", input_per_million=3.00, output_per_million=15.00),\n",
+    "]\n",
+    "\n",
+    "projections = project_costs(usage_summaries, target_games=100, pricings=pricing_table)\n",
+    "\n",
+    "for estimate in projections:\n",
+    "    print(f\"{estimate.provider} / {estimate.model} -> ${estimate.total_cost:.2f} ({estimate.currency})\")\n",
+    "    print(f\"  input tokens: {estimate.input_tokens:,}\")\n",
+    "    print(f\"  output tokens: {estimate.output_tokens:,}\")\n"
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Per-model usage captured from Inspect logs:\n",
+      "  - openai/gpt-4o-mini: 3 samples, 2690 total tokens\n",
+      "  - anthropic/claude-3-5-sonnet: 3 samples, 3120 total tokens\n",
+      "OpenAI / openai/gpt-4o-mini -> $0.02 (USD)\n",
+      "  input tokens: 71,667\n",
+      "  output tokens: 18,000\n",
+      "Anthropic / anthropic/claude-3-5-sonnet -> $0.60 (USD)\n",
+      "  input tokens: 80,000\n",
+      "  output tokens: 24,000\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Reproducible Evaluation Loop\n",
+    "\n",
+    "The Inspect CLI exposes every ingredient we need for reproducible experiments. Run the following template once per model, updating the provider identifier and evaluation limit as needed:\n",
+    "\n",
+    "```bash\n",
+    "uv run inspect eval hangman_bench/hangman         --model <provider/model-id>         --limit 50         --log-dir runs/<provider>-<model>/\n",
+    "```\n",
+    "\n",
+    "Each run produces an `.inspect` log inside the log directory along with human-readable transcripts. Load those logs with `inspect_ai.log.read_eval_log` (or capture them directly from `inspect.eval(...)`) and feed the resulting `EvalLog` objects into the cost estimation helpers introduced above.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Paper Outline\n",
+    "\n",
+    "The final section sketches a publication-ready structure. Each bullet links back to deliverables generated earlier in the notebook:\n",
+    "\n",
+    "1. **Introduction** – Motivation for evaluating tool-using agents on Hangman; highlight dataset composition statistics.\n",
+    "2. **Related Work** – Survey tool-augmented reasoning benchmarks and prior Hangman solvers.\n",
+    "3. **Benchmark Description** – Describe the Inspect task configuration, solver architecture, and scoring pipeline.\n",
+    "4. **Experimental Setup** – Reference the experiment matrix and model list; detail prompt/call parameters.\n",
+    "5. **Results** – Present grouped accuracy, error bars, and qualitative transcripts; include cost analysis tables.\n",
+    "6. **Ablations** – Discuss effects of difficulty tiers, guess budgets, and optional word guesses.\n",
+    "7. **Discussion & Limitations** – Interpret strategic behaviours, failure modes, and token efficiency.\n",
+    "8. **Cost & Accessibility** – Summarise projected spend per provider and guidelines for budget-conscious replication.\n",
+    "9. **Conclusion** – Reflect on broader implications and future extensions (e.g., multilingual datasets)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- replace the JSONL-based token accounting helpers with a UsageSummary pipeline that consumes Inspect `EvalLog` objects directly
- refresh the experimental plan notebook to demonstrate building synthetic `EvalLog`s, aggregating usage via `summarise_eval_logs`, and projecting spend from Inspect logs
- clarify the reproducible evaluation instructions to point readers at `.inspect` logs and the Inspect Python API instead of raw transcripts

## Testing
- `uv run pytest` *(fails: TestHangmanE2E::test_hangman_incomplete_game expects 44 message limit but hangman.py returns 57; pre-existing mismatch)*


------
https://chatgpt.com/codex/tasks/task_e_68d47e35b5c48329be1ba6d59b106dba